### PR TITLE
Change script shebangs to #!/usr/bin/env bash for portability

### DIFF
--- a/do-firewall.sh
+++ b/do-firewall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ACCESS_TOKEN="REPLACE_ME"
 FIREWALL_ID=$(curl -s -X GET -H "Content-Type: application/json" -H "Authorization: Bearer ${ACCESS_TOKEN}" "https://api.digitalocean.com/v2/firewalls" | jq -r '.firewalls[0].id')
 FIREWALL_URL="https://api.digitalocean.com/v2/firewalls/${FIREWALL_ID}"

--- a/wstunnel.sh
+++ b/wstunnel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Original script downloaded from: https://github.com/Kirill888/notes/blob/wg-tunnel-update/wireguard/scripts/wstunnel.sh


### PR DESCRIPTION
This allows the scripts to run on non-FHS Linux distributions, for instance on NixOS.